### PR TITLE
Remove framework classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,6 @@ authors = [
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "Framework :: Hatch",
-  "Framework :: Pytest",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",


### PR DESCRIPTION
Hello there! Just FYI such classifiers are only meant to be used when writing plugins for said ecosystem. This is important to get an accurate list of projects when querying PyPI, for example: https://pypi.org/search/?c=Framework+%3A%3A+Hatch